### PR TITLE
Adding 1.0.6 to list of supported AngularJS versions

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -11,7 +11,7 @@ var angularFiles = [
   'angular-resource',
   'angular-sanitize'
 ];
-var angularVersions = ['1.0.5', '1.0.4', '1.0.3', '1.0.2', '1.0.1'];
+var angularVersions = ['1.0.6','1.0.5', '1.0.4', '1.0.3', '1.0.2', '1.0.1'];
 angularFiles.forEach(function (file) {
   versions[file] = angularVersions;
 });


### PR DESCRIPTION
Seeing this project for the first time today, hopefully this isn't in error.  Tested locally and it now writes the proper CDN version of 1.0.6 for grunt build.
