### PR TITLE
Make 'components.json' configurable via bowerrc

### DIFF
--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var semver = require('semver');
+var fs = require('fs');
 var hoist = require('../util/hoist.js');
 
 
@@ -12,13 +13,26 @@ var versions = require('../lib/data.js').versions;
 
 module.exports = function (grunt) {
 
+  function readBowerJson() {
+    var bowerrc = {};
+    var componentsFilename;
+
+    // Read bowerrc first, if present
+    if (fs.existsSync('.bowerrc')) {
+      bowerrc = grunt.file.readJSON('.bowerrc');
+    }
+
+    // If bowerrc defines a 'json' attribute, use that
+    componentsFilename = bowerrc.json || 'components.json';
+    return grunt.file.readJSON(componentsFilename);
+  }
+
   grunt.registerMultiTask('cdnify', 'replace scripts with refs to the Google CDN', function () {
     var options = this.options();
     // collect files
     var files = grunt.file.expand({ filter: 'isFile' }, this.data.html);
     var dest = options.dest;
-
-    var compJson = grunt.file.readJSON('component.json');
+    var compJson = readBowerJson();
 
     grunt.log
       .writeln('Going through ' + grunt.log.wordlist(files) + ' to update script refs');


### PR DESCRIPTION
To be prepared for bower 0.9, I like to set my `.bowerrc` to use `bower.json` instead of `components.json`. With this patch the `.bowerrc` is read to get the configures path.
