### PR TITLE
fix issue #13

### DIFF
--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -48,7 +48,8 @@ module.exports = function (grunt) {
       var content = file.body;
 
       grunt.util._.each(replacements, function (rep, name) {
-        var versionStr = compJson.dependencies[name] || compJson.devDependencies[name];
+        var versionStr = (compJson.dependencies && compJson.dependencies[name]) ||
+          (compJson.devDependencies && compJson.devDependencies[name]);
         if (!versionStr) {
           return;
         }


### PR DESCRIPTION
It now handle even if {dev}dependency do not exist in bower.json.
This should fix issue #13.
