### PR TITLE
fix(task): Support for custom bower directories

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -20,7 +20,7 @@ angularFiles.forEach(function (file) {
 
 angularFiles.forEach(function (item) {
   replacements[item] = {
-    from: 'components/' + item + '/' + item + '.js',
+    from: item + '/' + item + '.js',
     to: function (version) {
       return '//ajax.googleapis.com/ajax/libs/angularjs/' + version + '/' + item + '.min.js';
     }
@@ -34,7 +34,7 @@ angularFiles.forEach(function (item) {
 // scraped from: https://developers.google.com/speed/libraries/devguide
 versions.jquery = ['2.0.0', '1.9.1', '1.9.0', '1.8.3', '1.8.2', '1.8.1', '1.8.0', '1.7.2', '1.7.1', '1.7.0', '1.6.4', '1.6.3', '1.6.2', '1.6.1', '1.6.0', '1.5.2', '1.5.1', '1.5.0', '1.4.4', '1.4.3', '1.4.2', '1.4.1', '1.4.0', '1.3.2', '1.3.1', '1.3.0', '1.2.6', '1.2.3'];
 replacements.jquery = {
-  from: 'components/jquery/jquery.js',
+  from: 'jquery/jquery.js',
   to: function (version) {
     return '//ajax.googleapis.com/ajax/libs/jquery/' + version + '/jquery.min.js';
   }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "grunt": "~0.4.0",
     "grunt-contrib-jshint": "~0.4.3",
     "proxyquire": "~0.4.1",
-    "sinon": "~1.6.0",
     "grunt-contrib-nodeunit": "~0.1.2"
   },
   "dependencies": {
-    "semver": "~1.1.3"
+    "semver": "~1.1.3",
+    "bower": "~0.9.2"
   },
   "repository": {
     "type": "git",

--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -16,7 +16,7 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('cdnify', 'replace scripts with refs to the Google CDN', function () {
     // collect files
     var files = grunt.file.expand({ filter: 'isFile' }, this.data.html);
-    var compJson = bower.readJson();
+    var compJson = bower.readJson(grunt);
 
     grunt.log
       .writeln('Going through ' + grunt.log.wordlist(files) + ' to update script refs');
@@ -33,12 +33,14 @@ module.exports = function (grunt) {
 
       grunt.util._.each(replacements, function (rep, name) {
         var versionStr = compJson.dependencies[name] || compJson.devDependencies[name];
+        var from;
         if (!versionStr) {
           return;
         }
         var version = semver.maxSatisfying(versions[name], versionStr);
         if (version) {
-          content = content.replace(rep.from, rep.to(version));
+          from = bower.joinComponent(rep.from);
+          content = content.replace(from, rep.to(version));
         }
       });
 

--- a/test/bower_test.js
+++ b/test/bower_test.js
@@ -1,59 +1,29 @@
 'use strict';
 
 var proxyquire = require('proxyquire');
-var sinon = require('sinon');
 
 exports.bower = {
 
   setUp: function (cb) {
+    this.bowerConfig = {};
 
-    this.gruntMock = {
-      file: {
-        readJSON: sinon.stub()
-      }
-    };
-    this.gruntMock.file.readJSON.returns({key: 'value'});
-
-    this.fsMock = {
-      existsSync: sinon.stub()
+    this.bowerMock = {
+      config: this.bowerConfig
     };
 
-    this.bower = proxyquire('../util/bower', {
-      fs: this.fsMock
+    this.bowerUtil = proxyquire('../util/bower', {
+      bower: this.bowerMock
     });
 
     cb();
   },
 
-  tearDown: function (cb) {
-    this.fsMock.existsSync.reset();
-    this.gruntMock.file.readJSON.reset();
+  joinComponent: function (test) {
+    this.bowerConfig.directory = 'app/bower_components';
 
-    cb();
-  },
+    var result = this.bowerUtil.joinComponent('jquery/jquery-2.0.js');
+    test.equal(result, 'bower_components/jquery/jquery-2.0.js');
 
-  readJsonWithoutBowerrc: function (test) {
-    this.fsMock.existsSync.returns(false);
-
-    // Yay, depdendency injection!
-    var result = this.bower.readJson(this.gruntMock);
-    test.equals(result.key, 'value');
-
-    test.ok(this.fsMock.existsSync.calledWith('.bowerrc'));
-    // Fall back to component.json
-    test.ok(this.gruntMock.file.readJSON.calledWith('component.json'));
-
-    test.done();
-  },
-
-  readJsonWithBowerrc: function (test) {
-    this.fsMock.existsSync.returns(true);
-    this.gruntMock.file.readJSON.withArgs('.bowerrc').returns({json: 'myconf.json'});
-
-    this.bower.readJson(this.gruntMock);
-
-    // Use the provided config file.
-    test.ok(this.gruntMock.file.readJSON.calledWith('myconf.json'));
     test.done();
   }
 };

--- a/util/bower.js
+++ b/util/bower.js
@@ -1,19 +1,21 @@
 'use strict';
 
-var fs = require('fs');
-var bower = module.exports;
+var path = require('path');
+var bowerConfig = require('bower').config;
+var bowerUtil = module.exports;
 
 
-bower.readJson = function readJson(grunt) {
-  var bowerrc = {};
-  var componentsFilename;
+bowerUtil.readJson = function readJson(grunt) {
+  return grunt.file.readJSON(bowerConfig.json);
+};
 
-  // Read bowerrc first, if present
-  if (fs.existsSync('.bowerrc')) {
-    bowerrc = grunt.file.readJSON('.bowerrc');
-  }
+bowerUtil.joinComponent = function joinComponent(component) {
+  // Strip the leading path segment from the configured bower components
+  // directory. E.g. app/bower_components -> bower_components
+  var dirBits = bowerConfig.directory.split(path.sep);
+  dirBits.shift();
 
-  // If bowerrc defines a 'json' attribute, use that
-  componentsFilename = bowerrc.json || 'component.json';
-  return grunt.file.readJSON(componentsFilename);
+  // Always join the path with a forward slash, because it's used to replace the
+  // path in HTML.
+  return path.join(dirBits.join('/'), component);
 };


### PR DESCRIPTION
Instead of duplicating the logic to find the correct bower config file and
obtain the components directory from it, this uses the config object that bower
exposes. The data no longer contains a hard-coded `components/` prefix in their
path, but instead is joined with the bower path on runtime.

/fix #16
/ref #13

@btford What do you think? Is adding `bower` as dependency worth it?
