### PR TITLE
Adding link to list of libraries on Google CDN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # grunt-google-cdn [![Build Status](https://travis-ci.org/btford/grunt-google-cdn.png)](https://travis-ci.org/btford/grunt-google-cdn)
- Grunt task for replacing refs to resources on the Google CDN
+ Grunt task for replacing refs to resources on the [Google CDN](https://developers.google.com/speed/libraries/devguide)
 
 ## Getting Started
 This plugin requires Grunt `~0.4.0`


### PR DESCRIPTION
Link to list of libraries on the CDN was missing.
