### PR TITLE
Fix for Windows (currently doesn't work)

### DIFF
--- a/util/bower.js
+++ b/util/bower.js
@@ -17,5 +17,5 @@ bowerUtil.joinComponent = function joinComponent(component) {
 
   // Always join the path with a forward slash, because it's used to replace the
   // path in HTML.
-  return path.join(dirBits.join('/'), component);
+  return path.join(dirBits.join('/'), component).replace(/\\/g, '/');
 };


### PR DESCRIPTION
had to replace all back slashes to forward slashes explicitly since path.join() uses path.sep as the separator
