### PR TITLE
Removed OS specific use of path from bowerUtil

### DIFF
--- a/util/bower.js
+++ b/util/bower.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var path = require('path');
 var bowerConfig = require('bower').config;
 var bowerUtil = module.exports;
 
@@ -11,11 +10,13 @@ bowerUtil.readJson = function readJson(grunt) {
 
 bowerUtil.joinComponent = function joinComponent(component) {
   // Strip the leading path segment from the configured bower components
-  // directory. E.g. app/bower_components -> bower_components
-  var dirBits = bowerConfig.directory.split(path.sep);
+  // directory. E.g. app/bower_components -> bower_components'
+  // This assumes the directory is specified with a forward slash directory
+  // separator character.
+  var dirBits = bowerConfig.directory.split('/');
   dirBits.shift();
 
   // Always join the path with a forward slash, because it's used to replace the
   // path in HTML.
-  return path.join(dirBits.join('/'), component).replace(/\\/g, '/');
+  return [dirBits.join('/'), component].join('/');
 };


### PR DESCRIPTION
Using Node's `path` caused problems on Windows. This commit removes the platform variability from the task and assumes only forward slashes are used. This is always the case in HTML src attributes, but also in bower configuration files which are supposed to be OS independent.
