### PR TITLE
adding support to configure bower config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ cdnify: {
   }
 }
 ```
+You can specify the bower config location, it may be in a sub folder
+```js
+cdnify: {
+  dist: {
+    bowerConfig: 'client/bower.json'
+    html: ['app/*.html']
+  }
+}
+```
+
 You will need a valid bower.json/component.json file in your project, that has dependencies and a version listed accordingly
 
 ```json

--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -10,7 +10,7 @@ module.exports = function (grunt) {
   grunt.registerMultiTask('cdnify', 'replace scripts with refs to the Google CDN', function () {
     // collect files
     var files = grunt.file.expand({ filter: 'isFile' }, this.data.html);
-    var compJson = grunt.file.readJSON(bowerConfig.json);
+    var compJson = grunt.file.readJSON(this.data.bowerConfig || bowerConfig.json);
 
     // Strip the leading path segment off, e.g. `app/bower_components` ->
     // `bower_components`


### PR DESCRIPTION
In my project the Gruntfile.js aren't in the same folder as bower.json, then i had to add support to configure bower config path.
