### PR TITLE
Upgrade to google-cdn v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Within your Gruntfile.js file, you need to specify the html directory that conta
 
 ```js
 cdnify: {
+  options: {
+    cdn: 'google'
+  }
   dist: {
     html: ['app/*.html']
   }
@@ -47,6 +50,12 @@ You will need a valid bower.json/component.json file in your project, that has d
 ```
 
 If any updates are found, it will go through the files you specified, updating any references to those scripts.
+
+
+### Options
+
+- `cdn`: defaults to `google`. The CDN you want to use. For options consult the
+  [google-cdn docs](https://github.com/passy/google-cdn#api).
 
 
 ## Release History

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "grunt-contrib-nodeunit": "~0.1.2"
   },
   "dependencies": {
-    "bower": "~0.9.2",
-    "google-cdn": "~0.1.0"
+    "bower": ">=1.0.0",
+    "google-cdn": "~0.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I spent some hours this weekend adding support for different CDNs to `google-cdn` (which should definitely be renamed). I also got rid of the hard-coded main files and resolve them through bower, which required an API change to an asynchronous interface.

Currently only CDNJS is supported, because JSdelivr does not expose any but the most recent version and doesn't have _main_ file. I guess I could work around both those limitations, but wanted to get this out as a first step.

/cc @btford
/fixes #30
