### PR TITLE
update dependencies via npm-check-updates -u

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.0",
-    "grunt-contrib-jshint": "~0.4.3",
-    "proxyquire": "~0.4.1",
-    "grunt-contrib-nodeunit": "~0.1.2"
+    "grunt": "~0.4.1",
+    "grunt-contrib-jshint": "~0.6.4",
+    "proxyquire": "~0.5.1",
+    "grunt-contrib-nodeunit": "~0.2.1"
   },
   "dependencies": {
-    "bower": "~0.9.2",
-    "google-cdn": "~0.1.0"
+    "bower": "~1.2.6",
+    "google-cdn": "~0.2.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
primary motivation is to update the google-cdn dep from "~0.1.0" to "~0.2.2",
which adds support for cdnifying angular 1.0.8
