### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "bower": "~0.9.2",
-    "google-cdn": "~0.1.0"
+    "google-cdn": "~0.2.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
updated dependency on google-cdn to version 0.2.x.  The google-cdn project has been updated to handle the newer available versions of angular, but this project needs to be updated for it to be accessible.
