### PR TITLE
Update bower version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-nodeunit": "~0.1.2"
   },
   "dependencies": {
-    "bower": "~0.9.2",
+    "bower": "~1.2.8",
     "google-cdn": "~0.1.0"
   },
   "repository": {


### PR DESCRIPTION
grunt-google-cdn doest not work well in Node v0.11 .
The reason is bower.config used path.resolve, however it has been fixed already.
So we need to update this bower version.
