### PR TITLE
Capitalize task description

### DIFF
--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -7,7 +7,7 @@ var bowerConfig = require('bower').config;
 
 module.exports = function (grunt) {
 
-  grunt.registerMultiTask('cdnify', 'replace scripts with refs to the Google CDN', function () {
+  grunt.registerMultiTask('cdnify', 'Replace scripts with refs to the Google CDN', function () {
     // collect files
     var files = grunt.file.expand({ filter: 'isFile' }, this.data.html);
     var compJson = grunt.file.readJSON('bower.json');


### PR DESCRIPTION
Capitalize the first letter of the task description so it appears uniform with others listed by grunt --help.
