### PR TITLE
feat(task): acknowledge the user what urls have been changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "chalk": "^0.5.1",
     "grunt": "~0.4.0",
     "grunt-contrib-jshint": "~0.4.3",
     "proxyquire": "~0.4.1",
@@ -14,7 +15,7 @@
   },
   "dependencies": {
     "bower": ">=1.0.0",
-    "google-cdn": "~0.6.0"
+    "google-cdn": "~0.7.0"
   },
   "repository": {
     "type": "git",

--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var googlecdn = require('google-cdn');
 var bowerConfig = require('bower').config;
-
+var chalk = require('chalk');
 
 module.exports = function (grunt) {
 
@@ -37,9 +37,15 @@ module.exports = function (grunt) {
       content = googlecdn(content, compJson, {
         componentsPath: componentsPath,
         cdn: options.cdn
-      }, function (err, content) {
+      }, function (err, content, replacements) {
         if (err) {
           return cbInner(err);
+        }
+
+        if (replacements.length > 0) {
+          replacements.forEach(function (replacement) {
+            grunt.log.writeln(chalk.green('✔ ') + replacement.from + chalk.gray(' changed to ') + replacement.to);
+          });
         }
 
         grunt.file.write(file.path, content);


### PR DESCRIPTION
When using this task, I would like to see exactly what urls have been changed just like other grunt tasks. Especially work with grunt-usemin, the blocks are replaced so the scripts are not cdnified and this might confuse users. google-cdn needs to be modifed so also submitted a PR there https://github.com/passy/google-cdn/pull/22
