### PR TITLE
[multiple-cdn-source] condense cdn sources into single object if required

### DIFF
--- a/tasks/cdnify.js
+++ b/tasks/cdnify.js
@@ -15,6 +15,17 @@ module.exports = function (grunt) {
     var options = this.options({
       cdn: 'google'
     });
+    
+    // condense array of CDNs supplied into one source
+    if(grunt.util.kindOf(options.cdn) === 'array'){
+        var opts = {};
+        options.cdn.forEach(function(cdn) {
+            Object.keys(cdn).forEach(function(entry) {
+                opts[entry] = cdn[entry];
+            });
+        });
+        options.cdn = opts;
+    }
 
     // Strip the leading path segment off, e.g. `app/bower_components` ->
     // `bower_components`


### PR DESCRIPTION
Added support for multiple CDN sources and/or bespoke rules in grunt task definition.
e.g. 

``` javascript
options: {
  cdn: [
    require('cdnjs-cdn-data'),
    require('google-cdn-data'),
    {
      jquery: {
        versions: ['2.0.3', '2.0.2', '2.0.1', '2.0.0'],
        url: function (version) {
          return '//my.own.cdn/libs/jquery/' + version + '/jquery.min.js';
        }
      }
    }
  ]
}
```
