### PR TITLE
Tag new version for updated google-cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If any updates are found, it will go through the files you specified, updating a
   }
   ```
 For options consult the [google-cdn docs](https://github.com/passy/google-cdn#api).
-  
+
 ## CDN data modules
 
 - [google-cdn-data](https://github.com/shahata/google-cdn-data)
@@ -78,6 +78,8 @@ For options consult the [google-cdn docs](https://github.com/passy/google-cdn#ap
 
 ## Release History
 
+ * 2016-01-23   v0.5.0   updated packages
+ * ...
  * 2013-04-24   v0.1.4   removed the extra s in component.json
  * 2013-04-22   v0.1.3   Made 'components.json' configurable via bowerrc, added unstable AngularJS and jQuery 2.0.0
  * 2013-04-07   v0.1.2   update available AngularJS versions, add .jshintrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-google-cdn",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Grunt task for replacing refs to resources on the Google CDN",
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
   "name": "grunt-google-cdn",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Grunt task for replacing refs to resources on the Google CDN",
   "scripts": {
     "test": "grunt test"
   },
   "devDependencies": {
-    "each-async": "^1.1.1",
     "grunt": "~0.4.0",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-nodeunit": "^0.4.1",
@@ -15,6 +14,7 @@
   "dependencies": {
     "bower": ">=1.0.0",
     "chalk": "^1.0.0",
+    "each-async": "^1.1.1",
     "google-cdn": "^1.0.0"
   },
   "repository": {


### PR DESCRIPTION
Updated package version (to make changed google-cdn available)
Closes #66 
Closes #67 
Also moved each-async dependency:
Closes #68 
