### PR TITLE
upgrade google-cdn dependency to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "bower": ">=1.0.0",
     "chalk": "^1.0.0",
-    "google-cdn": "^1.0.0"
+    "google-cdn": "^1.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
google-cdn 1.0.0 has a dependency on an older version of bower which in turn has a dependency on an older version of handlebars which contains a security vulnerability (https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8861).